### PR TITLE
fix falco rule version comparison

### DIFF
--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -361,7 +361,7 @@ class SdSecureClient(PolicyEventsClientV1, PolicyEventsClientOld, _SdcCommon):
                     with open(cpath, 'r') as content_file:
                         try:
                             required_engine_version = int(os.path.basename(vpath))
-                            if vpath < 0:
+                            if int(os.path.basename(vpath)) < 0:
                                 return [False, "Variant directory {} must be a positive number".format(vpath)]
                             fobj["variants"].append({
                                 "requiredEngineVersion": required_engine_version,


### PR DESCRIPTION
Signed-off-by: kaizhe <derek0405@gmail.com>

Before the changes:

```
+ python src/deploy_falco_rules.py --host https://secure-xxxx.sysdig.com --user **** --password **** --python-sdc-dir sysdig-sdk-python
Backend supports falco rules files, also deploying falco rules files...
Could not set system rules file (b"Loading falco rules files from ./rules_files...\nCould not read content at ./rules_files/0.8.2/falco_rules.yaml/0/content: '<' not supported between instances of 'str' and 'int'\n"
```