### PR TITLE
fix(examples): Do not append 'updated via' in restore_alerts example

### DIFF
--- a/examples/restore_alerts.py
+++ b/examples/restore_alerts.py
@@ -78,17 +78,9 @@ with open(alerts_dump_file, 'r') as f:
         if a['name'] in existing_alerts:
             a['id'] = existing_alerts[a['name']]['id']
             a['version'] = existing_alerts[a['name']]['version']
-            if a.get('description') is None:
-                a['description'] = '(updated via restore_alerts.py)'
-            else:
-                a['description'] += ' (updated via restore_alerts.py)'
             ok, res = sdclient.update_alert(a)
             updated_count += 1
         else:
-            if a.get('description') is None:
-                a['description'] = '(created via restore_alerts.py)'
-            else:
-                a['description'] += ' (created via restore_alerts.py)'
             ok, res = sdclient.create_alert(alert_obj=a)
             created_count += 1
         if not ok:


### PR DESCRIPTION
Each time you restore alerts "updated via restore_alerts.py" in the description is appended so you get something like: "${DESCRITPION} updated via restore_alerts.py updated via restore_alerts.py updated via restore_alerts.py". 

This PR removes this part so the description doesn't grow anymore.

Fixes #135 