### PR TITLE
feat: get_dashboards now can retrieve full information

### DIFF
--- a/sdcclient/monitor/_dashboards_v3.py
+++ b/sdcclient/monitor/_dashboards_v3.py
@@ -47,7 +47,7 @@ class DashboardsClientV3(_SdcCommon):
                            verify=self.ssl_verify)
         return self._request_result(res)
 
-    def get_dashboards(self):
+    def get_dashboards(self, light=True):
         '''**Description**
             Return the list of dashboards available under the given user account. This includes the dashboards created by the user and the ones shared with her by other users.
 
@@ -57,7 +57,11 @@ class DashboardsClientV3(_SdcCommon):
         **Example**
             `examples/list_dashboards.py <https://github.com/draios/python-sdc-client/blob/master/examples/list_dashboards.py>`_
         '''
-        res = requests.get(self.url + self._dashboards_api_endpoint, params={"light": "true"}, headers=self.hdrs,
+        params = {
+            "light": light
+        }
+        res = requests.get(self.url + self._dashboards_api_endpoint, params=params,
+                           headers=self.hdrs,
                            verify=self.ssl_verify)
         return self._request_result(res)
 
@@ -280,7 +284,6 @@ class DashboardsClientV3(_SdcCommon):
             if not ok:
                 return ok, converted_scope
             template['scopeExpressionList'] = converted_scope
-
 
         # NOTE: Individual panels might override the dashboard scope, the override will NOT be reset
         if 'widgets' in template and template['widgets'] is not None:

--- a/specs/monitor/dashboards_v3_spec.py
+++ b/specs/monitor/dashboards_v3_spec.py
@@ -2,8 +2,7 @@ import json
 import os
 import tempfile
 
-from expects import expect, have_key, have_keys, contain, equal, start_with
-from expects.matchers.built_in import be_false, have_len, be_empty
+from expects import expect, have_key, have_keys, contain, equal, start_with, be_false, have_len, be_empty, not_
 from mamba import before, it, context, after, description
 
 from sdcclient import SdMonitorClient
@@ -75,6 +74,14 @@ with description("Dashboards v3", "integration") as self:
             ok, res = self.client.get_dashboards()
             expect((ok, res)).to(be_successful_api_call)
             expect(res).to(have_key("dashboards", contain(have_keys("name", "id"))))
+
+        with it("is able to list all the dashboards with the full information"):
+            ok, res = self.client.get_dashboards(light=False)
+            expect((ok, res)).to(be_successful_api_call)
+            expect(res).to(have_key("dashboards", contain(have_keys("name", "id",
+                                                                    panels=not_(be_empty),
+                                                                    layout=not_(be_empty),
+                                                                    permissions=not_(be_empty)))))
 
         with it("is able to retrieve the test dashboard by its id"):
             ok, res = self.client.get_dashboard(dashboard_id=self.test_dashboard["id"])


### PR DESCRIPTION
The previous version of the get_dashboards method was only able to retrieve partial information from the dashboards. The current one allows to disable the "light" mode.