### PR TITLE
fix(ci): Update scheduled test that fails due to retries

### DIFF
--- a/test/test_secure_apis.sh
+++ b/test/test_secure_apis.sh
@@ -14,11 +14,6 @@ if [[ $? != 1 ]]; then
    echo "set_secure_system_falco_rules.py succeeded when it should have failed"
    exit 1
 fi
-
-if [[ "$OUT" != "Access is denied: Not enough privileges to complete the action" ]]; then
-    echo "Unexpected output from set_secure_system_falco_rules.py: $OUT"
-    exit 1
-fi
 set -e
 
 # Get the system falco rules file. Don't validate it, just verify that it can be fetched.


### PR DESCRIPTION
The `set_secure_system_falco_rules.py` must fail because it's only allowed to set up the system falco rules in an on-prem installation. The script was looking for the string "Access is denied: Not enough privileges to complete the action" but since #159  the errors are using a retry strategy, and after 3 failure attempts, raise an exception instead of returning an error.
This PR removes the part that checks for the string since the new output is empty.