### PR TITLE
fix: Increase limit to retrieve policy events without pagination

### DIFF
--- a/examples/get_secure_policy_events.py
+++ b/examples/get_secure_policy_events.py
@@ -12,9 +12,6 @@
 #
 
 import getopt
-import json
-import operator
-import re
 import sys
 
 from sdcclient import SdSecureClient

--- a/examples/get_secure_policy_events.py
+++ b/examples/get_secure_policy_events.py
@@ -73,32 +73,8 @@ else:
 
 all_outputs = dict()
 
-while True:
+if not ok:
+    print(res)
+    sys.exit(1)
 
-    #
-    # Return the result
-    #
-    if not ok:
-        print(res)
-        sys.exit(1)
-
-    if not res["ctx"]["cursor"] or len(res['data']) == 0:
-        break
-
-    for event in res['data']:
-        if summarize:
-            sanitize_output = re.sub(r'\S+\s\(id=\S+\)', '', event['output'])
-            all_outputs[sanitize_output] = all_outputs.get(sanitize_output, 0) + 1
-        else:
-            sys.stdout.write(json.dumps(event) + "\n")
-
-    ok, res = sdclient.get_more_policy_events(res['ctx'])
-
-if summarize:
-    sorted = sorted(list(all_outputs.items()), key=operator.itemgetter(1), reverse=True)
-    count = 0
-    for val in sorted:
-        count += 1
-        sys.stdout.write("{} {}\n".format(val[1], val[0]))
-        if limit != 0 and count > limit:
-            break
+print(res["data"])

--- a/sdcclient/_monitor.py
+++ b/sdcclient/_monitor.py
@@ -1,5 +1,4 @@
 import json
-import re
 from typing import Any, Tuple, Union
 
 from sdcclient._common import _SdcCommon

--- a/sdcclient/secure/_policy_events_v1.py
+++ b/sdcclient/secure/_policy_events_v1.py
@@ -50,7 +50,7 @@ class PolicyEventsClientV1(_SdcCommon):
         '''
         options = {"from": int(from_sec) * 1_000_000_000,
                    "to": int(to_sec) * 1_000_000_000,
-                   "limit": 50,
+                   "limit": 999,
                    "filter": filter}
         ctx = {k: v for k, v in options.items() if v is not None}
         return self._get_policy_events_int(ctx)


### PR DESCRIPTION
Pagination in the Secure API doesn't honor the first API call, thus ignoring the duration specified in the parameters. This workaround increases the number of policies that can be retrieved in a single API call, and removes the pagination from the example.