### PR TITLE
SMBACK-6098 copy old values for defaultTeamRole and entryPoint

### DIFF
--- a/sdcclient/_common.py
+++ b/sdcclient/_common.py
@@ -853,6 +853,8 @@ class _SdcCommon(object):
             'canUseSysdigCapture': perm_capture if perm_capture else team['canUseSysdigCapture'],
             'canUseCustomEvents': perm_custom_events if perm_custom_events else team['canUseCustomEvents'],
             'canUseAwsMetrics': perm_aws_data if perm_aws_data else team['canUseAwsMetrics'],
+            'defaultTeamRole': team['defaultTeamRole'],
+            'entryPoint': team['entryPoint'],
             'id': team['id'],
             'version': team['version']
         }


### PR DESCRIPTION
Default role and entry point are resetting by sdclient.edit_team method

When customer calls sdcclient.remove_memberships (that calls edit_team)
two team attributes are resetting:default team, entry point