### PR TITLE
Fix `retry` warning

### DIFF
--- a/sdcclient/_common.py
+++ b/sdcclient/_common.py
@@ -11,7 +11,7 @@ class SysdigHTTPAdapter(HTTPAdapter):
         retry_strategy = Retry(
             total=3,
             status_forcelist=[403, 404, 429, 500, 502, 503, 504],
-            method_whitelist=["HEAD", "GET", "OPTIONS", "PUSH", "PUT"],
+            allowed_methods=["HEAD", "GET", "OPTIONS", "PUSH", "PUT"],
             backoff_factor=2,
         )
         kwargs["max_retries"] = retry_strategy


### PR DESCRIPTION
```
site-packages/sdcclient/_common.py:11: DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
```