### PR TITLE
fix: Solve timezone issue in ActivityAuditClientV1

### DIFF
--- a/sdcclient/secure/_activity_audit_v1.py
+++ b/sdcclient/secure/_activity_audit_v1.py
@@ -33,7 +33,7 @@ class ActivityAuditClientV1(_SdcCommon):
         Examples:
             >>> client = ActivityAuditClientV1(token=SECURE_TOKEN)
             >>>
-            >>> now = datetime.datetime.utcnow()
+            >>> now = datetime.datetime.now()
             >>> three_days_ago = now - datetime.timedelta(days=3)
             >>> max_event_number_retrieved = 50
             >>> data_sources = [ActivityAuditDataSource.CMD, ActivityAuditDataSource.KUBE_EXEC]

--- a/sdcclient/secure/_activity_audit_v1.py
+++ b/sdcclient/secure/_activity_audit_v1.py
@@ -49,9 +49,9 @@ class ActivityAuditClientV1(_SdcCommon):
         number_of_events_per_query = 50
 
         if from_date is None:
-            from_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            from_date = datetime.datetime.now() - datetime.timedelta(days=1)
         if to_date is None:
-            to_date = datetime.datetime.utcnow()
+            to_date = datetime.datetime.now()
 
         filters = scope_filter if scope_filter else []
         if data_sources:

--- a/specs/secure/activitylog_v1_spec.py
+++ b/specs/secure/activitylog_v1_spec.py
@@ -27,7 +27,7 @@ with description("Activity Audit v1", "integration") as self:
 
     with context("when listing the events from the last 3 days"):
         with it("retrieves all the events"):
-            three_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+            three_days_ago = datetime.datetime.now() - datetime.timedelta(days=3)
             ok, res = self.client.list_events(from_date=three_days_ago)
 
             expect((ok, res)).to(be_successful_api_call)


### PR DESCRIPTION
## Issue
When trying list_events() with following parameters:
```
    to_date = datetime.datetime.utcnow() 
    from_date = to_date - datetime.timedelta(seconds=40)
```
I have found that I retrieve events from 2 hours ago. Note: That my country is now UTC+2

## Reason
utcnow() returns a datetime without timezone:
```
bool(datetime.datetime.utcnow().tzinfo)
>>>False
```

And so when applying timestamp to it, then Python assumes your localtime, and so the 2 hours difference

## Fix
So using now(), that provides the localtime, fixes the previous issue 
Thanks @marojor for suggesting the fix 

## Tested 
Tested using a real sysdig customer:
1) Generating activity audit events
2) And then trying to retrieve the events with this API


