### PR TITLE
Add proxy support to sysdig client stack

### DIFF
--- a/sdcclient/_common.py
+++ b/sdcclient/_common.py
@@ -41,7 +41,7 @@ class _SdcCommon(object):
     '''
     lasterr = None
 
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None):
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None, proxies=None):
         self.token = os.environ.get("SDC_TOKEN", token)
         self.hdrs = self.__get_headers(custom_headers)
         self.url = os.environ.get("SDC_URL", sdc_url).rstrip('/')
@@ -56,6 +56,8 @@ class _SdcCommon(object):
         self.http = requests.Session()
         self.http.mount("https://", adapter)
         self.http.mount("http://", adapter)
+        if proxies:
+            self.http.proxies = proxies
 
     def __get_headers(self, custom_headers):
         headers = {

--- a/sdcclient/_monitor.py
+++ b/sdcclient/_monitor.py
@@ -7,8 +7,8 @@ from sdcclient.monitor import EventsClientV2, DashboardsClientV3
 
 class SdMonitorClient(DashboardsClientV3, EventsClientV2, _SdcCommon):
 
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None):
-        super(SdMonitorClient, self).__init__(token, sdc_url, ssl_verify, custom_headers)
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None, proxies=None):
+        super(SdMonitorClient, self).__init__(token, sdc_url, ssl_verify, custom_headers, proxies)
         self.product = "SDC"
 
     def get_alerts(self) -> Union[Tuple[bool, str], Tuple[bool, Any]]:

--- a/sdcclient/_monitor_v1.py
+++ b/sdcclient/_monitor_v1.py
@@ -14,8 +14,8 @@ class SdMonitorClientV1(SdMonitorClient):
         Handles dashboards version 1 (ie. up to February 2019). For later Sysdig Monitor versions, please use :class:`~SdMonitorClient` instead.
     '''
 
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True):
-        super(SdMonitorClientV1, self).__init__(token, sdc_url, ssl_verify)
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, proxies=None):
+        super(SdMonitorClientV1, self).__init__(token, sdc_url, ssl_verify, proxies)
         self._dashboards_api_version = 'v1'
         self._dashboards_api_endpoint = '/ui/dashboards'
         self._default_dashboards_api_endpoint = '/api/defaultDashboards'

--- a/sdcclient/_scanning.py
+++ b/sdcclient/_scanning.py
@@ -19,8 +19,8 @@ from sdcclient._common import _SdcCommon
 
 
 class SdScanningClient(ScanningAlertsClientV1, _SdcCommon):
-    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True, custom_headers=None):
-        super(SdScanningClient, self).__init__(token, sdc_url, ssl_verify, custom_headers)
+    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True, custom_headers=None, proxies=None):
+        super(SdScanningClient, self).__init__(token, sdc_url, ssl_verify, custom_headers, proxies)
         self.product = "SDS"
 
     def add_image(self, image, force=False, dockerfile=None, annotations={}, autosubscribe=True):

--- a/sdcclient/_secure.py
+++ b/sdcclient/_secure.py
@@ -10,8 +10,8 @@ class SdSecureClient(FalcoRulesFilesClientOld,
                      PolicyEventsClientOld,
                      PolicyClientV2,
                      _SdcCommon):
-    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True, custom_headers=None):
-        super(SdSecureClient, self).__init__(token, sdc_url, ssl_verify, custom_headers)
+    def __init__(self, token="", sdc_url='https://secure.sysdig.com', ssl_verify=True, custom_headers=None, proxies=None):
+        super(SdSecureClient, self).__init__(token, sdc_url, ssl_verify, custom_headers, proxies)
 
         self.product = "SDS"
         self._policy_v2 = None

--- a/sdcclient/monitor/_dashboards_v2.py
+++ b/sdcclient/monitor/_dashboards_v2.py
@@ -7,8 +7,8 @@ from sdcclient.monitor.dashboard_converters._dashboard_scope import convert_scop
 
 
 class DashboardsClientV2(_SdcCommon):
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None):
-        super(DashboardsClientV2, self).__init__(token, sdc_url, ssl_verify, custom_headers)
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None, proxies=None):
+        super(DashboardsClientV2, self).__init__(token, sdc_url, ssl_verify, custom_headers, proxies)
         self.product = "SDC"
         self._dashboards_api_version = 'v2'
         self._dashboards_api_endpoint = '/api/{}/dashboards'.format(self._dashboards_api_version)

--- a/sdcclient/monitor/_dashboards_v3.py
+++ b/sdcclient/monitor/_dashboards_v3.py
@@ -10,8 +10,8 @@ PANEL_VISUALIZATION_NUMBER = "advancedNumber"
 
 
 class DashboardsClientV3(_SdcCommon):
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None):
-        super(DashboardsClientV3, self).__init__(token, sdc_url, ssl_verify, custom_headers)
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None, proxies=None):
+        super(DashboardsClientV3, self).__init__(token, sdc_url, ssl_verify, custom_headers, proxies)
         self.product = "SDC"
         self._dashboards_api_version = 'v3'
         self._dashboards_api_endpoint = '/api/{}/dashboards'.format(self._dashboards_api_version)

--- a/sdcclient/monitor/_events_v1.py
+++ b/sdcclient/monitor/_events_v1.py
@@ -4,8 +4,8 @@ from sdcclient._common import _SdcCommon
 
 
 class EventsClientV1(_SdcCommon):
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None):
-        super().__init__(token, sdc_url, ssl_verify, custom_headers)
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None, proxies=None):
+        super().__init__(token, sdc_url, ssl_verify, custom_headers, proxies)
         self.product = "SDC"
 
     def get_events(self, from_s=None, to_s=None, last_s=None):

--- a/sdcclient/monitor/_events_v2.py
+++ b/sdcclient/monitor/_events_v2.py
@@ -5,8 +5,8 @@ from sdcclient._common import _SdcCommon
 
 
 class EventsClientV2(_SdcCommon):
-    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None):
-        super().__init__(token, sdc_url, ssl_verify, custom_headers)
+    def __init__(self, token="", sdc_url='https://app.sysdigcloud.com', ssl_verify=True, custom_headers=None, proxies=None):
+        super().__init__(token, sdc_url, ssl_verify, custom_headers, proxies)
         self.product = "SDC"
 
     def get_events(self, name=None, category=None, direction='before', status=None, limit=100, pivot=None, from_s=None,


### PR DESCRIPTION
These changes will allow the initializer to add a proxy at initialization of the client to add to the request session, for use for all requests in that instantiation.