### PR TITLE
fix: declare sphinx-rtd-theme in docs extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ flake8 = "^3.8.4"
 coverage = "^6.2"
 
 [tool.poetry.extras]
-docs = ["sphinx", "sphinx-material"]
+docs = ["sphinx", "sphinx-material", "sphinx-rtd-theme"]
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Currently sphinx-rtd-theme is incorrectly being included in the main group dependencies and hence pulls in itself and sphinx as a runtime dep for the client. Declaring it in the docs group ensures it is only installed if the `sdcclient[docs]` is installed.

Not only does this pull in a number of unnecessary dependencies, it also forces a backlevel urllib3 1.x to be used. Here's the before and after this PR of a `pip install sdcclient` into an empty venv:
```diff
@@ -1,29 +1,12 @@
 Package                       Version
 ----------------------------- --------
-alabaster                     0.7.16
-babel                         2.15.0
 certifi                       2024.6.2
 charset-normalizer            3.3.2
-docutils                      0.17.1
 idna                          3.7
-imagesize                     1.4.1
-jinja2                        3.1.4
-markupsafe                    2.1.5
-packaging                     24.0
 pyaml                         21.10.1
-pygments                      2.18.0
 pyyaml                        6.0.1
 requests                      2.32.3
-requests-toolbelt             0.9.1
+requests-toolbelt             1.0.0
 sdcclient                     0.17.1
-snowballstemmer               2.2.0
-sphinx                        5.3.0
-sphinx-rtd-theme              1.0.0
-sphinxcontrib-applehelp       1.0.8
-sphinxcontrib-devhelp         1.0.6
-sphinxcontrib-htmlhelp        2.0.5
-sphinxcontrib-jsmath          1.0.1
-sphinxcontrib-qthelp          1.0.7
-sphinxcontrib-serializinghtml 1.1.10
 tatsu                         5.8.3
-urllib3                       1.26.18
+urllib3                       2.2.1
```