### PR TITLE
Fix exception in case no hostname label is available

### DIFF
--- a/sdcclient/_common.py
+++ b/sdcclient/_common.py
@@ -509,7 +509,7 @@ class _SdcCommon(object):
         capture_agent = None
 
         for agent in res[1]:
-            if hostname == agent['hostName']:
+            if hostname == agent.get('hostName'):
                 capture_agent = agent
                 break
 


### PR DESCRIPTION
### Due to 
I have seen a failure trying to create a capture due to: 
![image](https://github.com/user-attachments/assets/03004692-6824-4960-9ee2-86ee4a5aeb9c)


### Changes 
This PR protects the use of hostName key from agent dictionary