### PR TITLE
fix: use raw string for dashboard scope grammar

### DIFF
--- a/sdcclient/monitor/dashboard_converters/_dashboard_scope.py
+++ b/sdcclient/monitor/dashboard_converters/_dashboard_scope.py
@@ -5,7 +5,7 @@ def convert_scope_string_to_expression(scope=None):
     if scope is None or not scope:
         return [True, []]
 
-    _SCOPE_GRAMMAR = """
+    _SCOPE_GRAMMAR = r"""
         @@grammar::CALC
 
         start = expression $ ;


### PR DESCRIPTION
Use raw string (r-string) prefix for the dashboard scope grammar
string to prevent invalid escape sequence warnings for \- and \.
patterns in the grammar.

This resolves SyntaxWarning issues in Python 3.13+. All existing tests pass.
```
python3.13/site-packages/sdcclient/monitor/dashboard_converters/_dashboard_scope.py:8: SyntaxWarning: invalid escape sequence '\-'
  _SCOPE_GRAMMAR = """
```